### PR TITLE
[BTC-122] - Fix physics not available yet error

### DIFF
--- a/Source/Scripts/Camera/player_camera.gd
+++ b/Source/Scripts/Camera/player_camera.gd
@@ -8,17 +8,22 @@ extends Camera3D
 @onready var ray_cast_3d: RayCast3D = $RayCast3D
 
 # if we don't hit anything, we return the last direction
-var last_position_collision : Vector3 = Vector3.ZERO
-
+var _last_position_collision : Vector3 = Vector3.ZERO
+var _last_point_query : Vector2 = Vector2.ZERO
 
 ## this will convert a 2D point to 3D
-func get_world_position_from_point(point: Vector2) -> Vector3:
+func _physics_process(delta: float) -> void:
 	# we project the given point
-	ray_cast_3d.target_position = project_local_ray_normal(point) * world_position_ray_length
+	ray_cast_3d.target_position = project_local_ray_normal(_last_point_query) * world_position_ray_length
 	# we force to update the collision for this new ray
 	ray_cast_3d.force_raycast_update()
 	#if collided with something, we get that collision point
 	if ray_cast_3d.is_colliding():
-		last_position_collision = ray_cast_3d.get_collision_point()
+		_last_position_collision = ray_cast_3d.get_collision_point()
+	
+## this will convert a 2D point to 3D
+func get_world_position_from_point(point: Vector2) -> Vector3:
+	# we cache the current point to be queried
+	_last_point_query = point
 	# we return the calculated position
-	return last_position_collision
+	return _last_position_collision


### PR DESCRIPTION
To fix the error, we moved the raycast calculations to the physics_proccess method

Error: player_camera.gd:19 @ get_world_position_from_point(): Space state is inaccessible right now, wait for iteration or physics process notification

Resolves #122