### PR TITLE
[BTC-177] - Creating a Shooting Cost Strategy that handles when the player can shoot

### DIFF
--- a/Source/Resources/Shooting/ShootingCostStrategies/enemy_timed_shooting_cost_strategy.tres.tres
+++ b/Source/Resources/Shooting/ShootingCostStrategies/enemy_timed_shooting_cost_strategy.tres.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class="TimedShootingCostStrategy" format=3 uid="uid://dbwvhjyvhkcaf"]
+
+[ext_resource type="Script" uid="uid://bim3ckfauijxb" path="res://Scripts/Shooting/ShootingCostStrategies/Strategies/timed_shooting_cost_strategy.gd" id="1_73q6w"]
+
+[resource]
+script = ExtResource("1_73q6w")
+metadata/_custom_type_script = "uid://bim3ckfauijxb"

--- a/Source/Resources/Shooting/ShootingCostStrategies/player_timed_shooting_cost_strategy.tres.tres
+++ b/Source/Resources/Shooting/ShootingCostStrategies/player_timed_shooting_cost_strategy.tres.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class="TimedShootingCostStrategy" format=3 uid="uid://dicynpv4k6gg0"]
+
+[ext_resource type="Script" uid="uid://bim3ckfauijxb" path="res://Scripts/Shooting/ShootingCostStrategies/Strategies/timed_shooting_cost_strategy.gd" id="1_xasoe"]
+
+[resource]
+script = ExtResource("1_xasoe")
+metadata/_custom_type_script = "uid://bim3ckfauijxb"

--- a/Source/Resources/Weapons/player_weapon_stats.tres
+++ b/Source/Resources/Weapons/player_weapon_stats.tres
@@ -5,5 +5,6 @@
 
 [resource]
 script = ExtResource("2_lvb5j")
+fire_rate = 0.5
 projectile_scene = ExtResource("1_hc5x6")
 metadata/_custom_type_script = "uid://b5pgjkvc106as"

--- a/Source/Scenes/Weapon/enemy_weapon_system.tscn
+++ b/Source/Scenes/Weapon/enemy_weapon_system.tscn
@@ -2,11 +2,9 @@
 
 [ext_resource type="Script" uid="uid://befq5lr3d6qb1" path="res://Scripts/Weapon/weapon_system.gd" id="1_t0jxb"]
 [ext_resource type="Resource" uid="uid://dlodrdxmlsqnu" path="res://Resources/Weapons/enemy_weapon_stats.tres" id="2_t0jxb"]
+[ext_resource type="Resource" uid="uid://dbwvhjyvhkcaf" path="res://Resources/Shooting/ShootingCostStrategies/enemy_timed_shooting_cost_strategy.tres.tres" id="3_d3twt"]
 
 [node name="WeaponSystem" type="Node" unique_id=523735498]
 script = ExtResource("1_t0jxb")
 _weapon_stats = ExtResource("2_t0jxb")
-
-[node name="FireRateTimer" type="Timer" parent="." unique_id=309717371]
-
-[connection signal="timeout" from="FireRateTimer" to="." method="_on_fire_rate_timer_timeout"]
+_shooting_cost_strategy = ExtResource("3_d3twt")

--- a/Source/Scenes/Weapon/player_weapon_system.tscn
+++ b/Source/Scenes/Weapon/player_weapon_system.tscn
@@ -2,11 +2,9 @@
 
 [ext_resource type="Script" uid="uid://befq5lr3d6qb1" path="res://Scripts/Weapon/weapon_system.gd" id="1_1n27g"]
 [ext_resource type="Resource" uid="uid://df8ghheytbtt5" path="res://Resources/Weapons/player_weapon_stats.tres" id="2_1n27g"]
+[ext_resource type="Resource" uid="uid://dicynpv4k6gg0" path="res://Resources/Shooting/ShootingCostStrategies/player_timed_shooting_cost_strategy.tres.tres" id="3_udpco"]
 
 [node name="WeaponSystem" type="Node" unique_id=523735498]
 script = ExtResource("1_1n27g")
 _weapon_stats = ExtResource("2_1n27g")
-
-[node name="FireRateTimer" type="Timer" parent="." unique_id=309717371]
-
-[connection signal="timeout" from="FireRateTimer" to="." method="_on_fire_rate_timer_timeout"]
+_shooting_cost_strategy = ExtResource("3_udpco")

--- a/Source/Scripts/ControllableEntity/controllable_entity.gd
+++ b/Source/Scripts/ControllableEntity/controllable_entity.gd
@@ -59,7 +59,7 @@ func _process(delta) -> void:
 	# we get if the player pressed shot input
 	var has_shot : bool = _entity_controller.is_shot_pressed()
 	# we process the shot information if pressed
-	_weapon_system.process_shot(has_shot, _muzzle)
+	_weapon_system.try_shot(has_shot, _muzzle)
 
 
 func _physics_process(_delta) -> void:

--- a/Source/Scripts/Projectiles/ProjectileStats/projectile_stats.gd
+++ b/Source/Scripts/Projectiles/ProjectileStats/projectile_stats.gd
@@ -2,7 +2,7 @@ class_name ProjectileStats
 extends Resource
 
 ## how fast the projectile will move
-@export_range(1, 100) var speed : float = 10:
+@export_range(0.0, 100.0) var speed : float = 10.0:
 	get():
 		return speed
 	set(new_value):

--- a/Source/Scripts/Shooting/ShootingCostStrategies/Strategies/timed_shooting_cost_strategy.gd
+++ b/Source/Scripts/Shooting/ShootingCostStrategies/Strategies/timed_shooting_cost_strategy.gd
@@ -1,0 +1,23 @@
+extends ShootingCostStrategy
+class_name TimedShootingCostStrategy
+
+# time accumulator
+var _time_passed : float = 0.0
+
+
+## this will check for the fire rate time to tell us if it's able to shoot
+func _can_shot(weapon_stats: WeaponStats) -> bool:
+	# if the time passed and is higher than the fire rate we can shoot
+	if _time_passed > weapon_stats.fire_rate:
+		# we reset the timer
+		_time_passed = 0
+		# we say that we can shoot
+		return true
+	# is not ready to shoot
+	return false
+
+
+## here we update the time passed
+func _process_update_conditions(delta: float) -> void:
+	# we increment the time passed in this frame
+	_time_passed += delta

--- a/Source/Scripts/Shooting/ShootingCostStrategies/Strategies/timed_shooting_cost_strategy.gd.uid
+++ b/Source/Scripts/Shooting/ShootingCostStrategies/Strategies/timed_shooting_cost_strategy.gd.uid
@@ -1,0 +1,1 @@
+uid://bim3ckfauijxb

--- a/Source/Scripts/Shooting/ShootingCostStrategies/shooting_cost_strategy.gd
+++ b/Source/Scripts/Shooting/ShootingCostStrategies/shooting_cost_strategy.gd
@@ -1,0 +1,13 @@
+extends Resource
+class_name ShootingCostStrategy
+
+
+## this will tell us if the owner has the requisites for shooting
+func _can_shot(_weapon_stats: WeaponStats) -> bool:
+	push_error("_can_shot() should be implemented on inherited")
+	return false
+
+
+## here we can update the conditions
+func _process_update_conditions(_delta: float) -> void:
+	push_error("_process_update_conditions() should be implemented on inherited")

--- a/Source/Scripts/Shooting/ShootingCostStrategies/shooting_cost_strategy.gd.uid
+++ b/Source/Scripts/Shooting/ShootingCostStrategies/shooting_cost_strategy.gd.uid
@@ -1,0 +1,1 @@
+uid://bm06ydamxrhh7

--- a/Source/Scripts/Weapon/WeaponStats/weapon_stats.gd
+++ b/Source/Scripts/Weapon/WeaponStats/weapon_stats.gd
@@ -2,11 +2,12 @@ class_name WeaponStats
 extends Resource
 
 ## how long it will wait between shots
-@export_range(1, 100) var fire_rate : float = 1:
+@export_range(0.0, 10.0) var fire_rate : float = 1.0:
 	get():
 		return fire_rate
 	set(new_value):
 		fire_rate = new_value
+
 
 ## projectile scene to instantiate
 @export var projectile_scene : PackedScene:

--- a/Source/Scripts/Weapon/weapon_system.gd
+++ b/Source/Scripts/Weapon/weapon_system.gd
@@ -4,40 +4,19 @@ extends Node
 ## Weapon stats like velocity and damage
 @export var _weapon_stats : WeaponStats
 
-# this timer will reset the variable that allow us to shot 
-@onready var _fire_rate_timer: Timer = $FireRateTimer
-
-# this will be enabled every time the timer timeouts
-var _can_shot : bool = false
+## Weapon stats like velocity and damage
+@export var _shooting_cost_strategy : ShootingCostStrategy
 
 
-func _ready() -> void:
-	# we set the wait time for the timer as the fire rate
-	_fire_rate_timer.wait_time = _weapon_stats.fire_rate
-	# we start the timer
-	_fire_rate_timer.start()
+func _process(delta: float) -> void:
+	_shooting_cost_strategy._process_update_conditions(delta)
 
 
-func process_shot(has_shoot : bool, muzzle: Marker3D) -> void:
-	if has_shoot and _can_shot:
+func try_shot(has_shoot_pressed : bool, muzzle: Marker3D) -> void:
+	if has_shoot_pressed and _shooting_cost_strategy._can_shot(_weapon_stats):
 		# we instantiate the projectile
-		var shot = _weapon_stats.projectile_scene.instantiate() as Projectile
+		var shot : Projectile = _weapon_stats.projectile_scene.instantiate() as Projectile
 		# we add the shot to the scene (after this ready function will be triggered)
 		add_child(shot)
 		# we fire the shot
 		shot.fire(muzzle)
-		# we reset the timer
-		restart_timer()
-
-
-# we need to stop and start again to restart
-func restart_timer() -> void:
-	# we say we cant shot after the timer resets
-	_can_shot = false
-	_fire_rate_timer.stop()
-	_fire_rate_timer.start()
-
-
-# we the time ends, we say that we can shot again
-func _on_fire_rate_timer_timeout() -> void:
-	_can_shot = true


### PR DESCRIPTION
Created a shooting cost strategy which will handle if the owner can shoot or not 
Created a timed shooting cost strategy which handles the accumulated time and fire rate to allow to shoot 
Removed not needed Timer node from Weapon Systems

Resolves #177