### PR TITLE
[BTC-197] - Make the enemies avoid each other and player by using NavigationObstacle3D

### DIFF
--- a/Source/Scenes/ControllableEntity/controllable_enemy_entity.tscn
+++ b/Source/Scenes/ControllableEntity/controllable_enemy_entity.tscn
@@ -62,6 +62,9 @@ _navigation_agent = NodePath("../NavigationAgent3D")
 owner_controllable_entity = NodePath("..")
 
 [node name="NavigationAgent3D" type="NavigationAgent3D" parent="." unique_id=1295136493]
+avoidance_enabled = true
+radius = 1.2
+neighbor_distance = 20.0
 
 [node name="Health" parent="." unique_id=1679365679 instance=ExtResource("9_1qpgy")]
 unique_name_in_owner = true
@@ -75,7 +78,9 @@ shape = SubResource("BoxShape3D_tugb3")
 [node name="StateMachine" parent="." unique_id=994521171 node_paths=PackedStringArray("_ai_controller") instance=ExtResource("9_xtgfm")]
 _ai_controller = NodePath("../AiController")
 
+[connection signal="entity_stats_set" from="." to="AiController" method="_on_enemy_entity_stats_set"]
 [connection signal="shot_fired" from="WeaponSystem" to="StateMachine" method="_on_weapon_system_shot_fired"]
 [connection signal="target_reached" from="NavigationAgent3D" to="StateMachine" method="_on_navigation_agent_3d_target_reached"]
+[connection signal="velocity_computed" from="NavigationAgent3D" to="AiController" method="_on_navigation_agent_3d_velocity_computed"]
 
 [editable path="StateMachine"]

--- a/Source/Scripts/ControllableEntity/controllable_entity.gd
+++ b/Source/Scripts/ControllableEntity/controllable_entity.gd
@@ -1,6 +1,9 @@
 class_name ControllableEntity
 extends CharacterBody3D
 
+## This signal is emitted when the entity stats are set
+signal entity_stats_set
+
 @export_group("Events")
 @export var _on_input_changed_event : BaseEvent
 @export var _on_menu_opened_event : BaseEvent
@@ -29,6 +32,11 @@ var _entity_stats : EntityStats:
 	get():
 		return _entity_stats_manager.entity_stats()
 
+# the entity move speed shorthand access
+var entity_move_speed : float:
+	get():
+		return _entity_stats.move_speed
+
 
 func _ready() -> void:
 	#we set the callbacks for the healths
@@ -37,13 +45,15 @@ func _ready() -> void:
 	_on_input_changed_event.subscribe(_entity_controller.on_input_type_changed)
 	#we listen to the event signal when the menu is opened
 	_on_menu_opened_event.subscribe(_entity_controller.on_menu_opened)
+	# emit a signal to notify that the correct entity stats is set
+	entity_stats_set.emit()
 
 
 func _process(delta) -> void:
 	# we get the wanted move direction
 	var move_direction : Vector3 = _entity_controller.get_move_direction()
 	# we calculate a desired velocity
-	var target_velocity : Vector3 = move_direction * _entity_stats.move_speed
+	var target_velocity : Vector3 = move_direction * entity_move_speed
 	# we apply gravity to the body
 	var applied_gravity : float = _process_gravity()
 	# we are incrementing the velocity to make it match the desired velocity

--- a/Source/Scripts/EntityController/Controllers/ai_controller.gd
+++ b/Source/Scripts/EntityController/Controllers/ai_controller.gd
@@ -23,9 +23,12 @@ func get_move_direction() -> Vector3:
 	# we take the next position on the navmesh
 	var next_position : Vector3 = _navigation_agent.get_next_path_position()
 	# we take the direction between our owner position and the next
-	# path position to know in which direction we need to move
-	_target_position = owner_controllable_entity.global_position.direction_to(next_position)
-	# we return the desired position
+	# path position to know in which intended direction we need to move
+	var intended_direction : Vector3 = owner_controllable_entity.global_position.direction_to(next_position)
+	# we set intended velocity to the navigation agent for avoidance calculation
+	_navigation_agent.velocity = intended_direction.normalized()
+	# Return the safe position which is calculated 
+	# by the avoidance callback previously
 	return _target_position
 
 
@@ -79,3 +82,16 @@ func set_random_target_position() -> void:
 	_target_position = NavigationServer3D.region_get_random_point(_region_rid, 1, false)
 	# we set the new target destination position
 	_navigation_agent.set_target_position(_target_position)
+
+
+func _on_navigation_agent_3d_velocity_computed(safe_velocity: Vector3) -> void:
+	# We cache the computed safe velocity that the navigation agent calculated
+	# while having avoidance capabilities for the entity
+	_target_position = safe_velocity
+
+
+func _on_enemy_entity_stats_set() -> void:
+	# to avoid issues, we set the agent max avoidance speed equals to
+	# the entity movement speed
+	# keep a safe default here; actual speed should be set by the owner
+	_navigation_agent.max_speed = owner_controllable_entity.entity_move_speed

--- a/Source/project.godot
+++ b/Source/project.godot
@@ -94,10 +94,20 @@ joypads/ignore_joypad_on_unfocused_application=true
 [layer_names]
 
 3d_physics/layer_1="World"
+3d_navigation/layer_1="World"
 3d_physics/layer_2="Player"
+3d_navigation/layer_2="Player"
 3d_physics/layer_3="Enemy"
+3d_navigation/layer_3="Enemy"
 3d_physics/layer_9="PlayerProjectiles"
+3d_navigation/layer_9="PlayerProjectiles"
 3d_physics/layer_10="EnemyProjectiles"
+3d_navigation/layer_10="EnemyProjectiles"
+avoidance/layer_1="World"
+avoidance/layer_2="Player"
+avoidance/layer_3="Enemy"
+avoidance/layer_9="PlayerProjectiles"
+avoidance/layer_10="EnemyProjectiles"
 
 [physics]
 


### PR DESCRIPTION
## Dev

- Enabled avoidance from the NavigationAgent3D
- Set avoidance values in the enemy scene
- Created a new signal to let the entities know their listeners that the entity stats are been set
- Connected the signal to the ai controller which is going to set the navigation agent a max speed by using the entity move speed
- AI Controller now moves by the avoidance values get from the navigation agent
- Set layer names

Resolves #197