### PR TITLE
[BTC-213] - Investigate Moving the State Machine Closer to the AI Controller

### DIFF
--- a/Source/Scenes/ControllableEntity/controllable_enemy_entity.tscn
+++ b/Source/Scenes/ControllableEntity/controllable_enemy_entity.tscn
@@ -75,12 +75,10 @@ health_stats = ExtResource("10_1qpgy")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.357062, -0.23291)
 shape = SubResource("BoxShape3D_tugb3")
 
-[node name="StateMachine" parent="." unique_id=994521171 node_paths=PackedStringArray("_ai_controller") instance=ExtResource("9_xtgfm")]
+[node name="StateMachine" parent="." unique_id=994521171 node_paths=PackedStringArray("_ai_controller", "_navigation_agent", "_weapon_system") instance=ExtResource("9_xtgfm")]
 _ai_controller = NodePath("../AiController")
+_navigation_agent = NodePath("../NavigationAgent3D")
+_weapon_system = NodePath("../WeaponSystem")
 
 [connection signal="entity_stats_set" from="." to="AiController" method="_on_enemy_entity_stats_set"]
-[connection signal="shot_fired" from="WeaponSystem" to="StateMachine" method="_on_weapon_system_shot_fired"]
-[connection signal="target_reached" from="NavigationAgent3D" to="StateMachine" method="_on_navigation_agent_3d_target_reached"]
 [connection signal="velocity_computed" from="NavigationAgent3D" to="AiController" method="_on_navigation_agent_3d_velocity_computed"]
-
-[editable path="StateMachine"]

--- a/Source/Scripts/Health/hurt.gd
+++ b/Source/Scripts/Health/hurt.gd
@@ -11,7 +11,7 @@ signal _on_damage_taken
 ## to avoid having to connect this signal on
 ## every node, we connect it here
 func _ready() -> void:
-	connect("area_entered", _on_area_entered)
+	area_entered.connect(_on_area_entered)
 
 
 ## we cache references

--- a/Source/Scripts/StateMachine/Normal/normal_state_machine.gd
+++ b/Source/Scripts/StateMachine/Normal/normal_state_machine.gd
@@ -1,11 +1,23 @@
 extends Node
 class_name NormalStateMachine
 
+@export_group("References")
 ## the entity controller reference
 @export var _ai_controller : AIController
+## the navigation agent that reports when a wander target is reached
+@export var _navigation_agent : NavigationAgent3D
+## the weapon system that reports when a shot was fired
+@export var _weapon_system : WeaponSystem
 
 ## the entity state chart for triggering state events
 @onready var state_chart: StateChart = %"StateChart"
+
+
+## to avoid having to connect these signals on every entity,
+## we connect them here
+func _ready() -> void:
+	_navigation_agent.target_reached.connect(_on_navigation_agent_3d_target_reached)
+	_weapon_system.shot_fired.connect(_on_weapon_system_shot_fired)
 
 
 func _on_wander_state_entered() -> void:


### PR DESCRIPTION
- We don't need an editable children for the state machine so we disable it
- In order to make the state machine more reusable, we added the exports needed to connect the signals in the ready function
- This changes will allow us to take this state machine into another type of entity and only assign the references and it should work fine
- Updated connect hurt callback method

Resolves #213